### PR TITLE
Fixing incorrect option value select

### DIFF
--- a/src/Resources/public/js/searchConfig/conditionEntryPanel.js
+++ b/src/Resources/public/js/searchConfig/conditionEntryPanel.js
@@ -70,7 +70,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.conditionEntryPanel = Class.cre
                 displayField: 'fieldLabel',
                 listeners: {
                     change: function( item, newValue, oldValue, eOpts ) {
-                        var record = item.getStore().findRecord('fieldName', newValue);
+                        var record = item.getStore().getAt(item.getStore().findExact('fieldName', newValue));
                         if(record) {
                             var fieldSelectionInformation = record.data;
 

--- a/src/Resources/public/js/searchConfig/fieldConditionPanel/fieldcollections.js
+++ b/src/Resources/public/js/searchConfig/fieldConditionPanel/fieldcollections.js
@@ -129,7 +129,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.fieldConditionPanel.fieldcollec
                 displayField: 'fieldLabel',
                 listeners: {
                     change: function( item, newValue, oldValue, eOpts ) {
-                        var record = item.getStore().findRecord('fieldName', newValue);
+                        var record = item.getStore().getAt(item.getStore().findExact('fieldName', newValue));
                         if(record) {
                             var fieldSelectionInformation = record.data;
 


### PR DESCRIPTION
This pull request fixes following problem:
When class has 2 fields with following names:
- nameWithSomeSufix
- name
and user selects in Advanced Object Search Condition panel field "name" plugin will search by "nameWithSomeSufix" field.