### PR TITLE
Usability Improvements (Column Width, Result Panel)

### DIFF
--- a/src/Resources/public/js/searchConfig/conditionEntryPanel.js
+++ b/src/Resources/public/js/searchConfig/conditionEntryPanel.js
@@ -84,6 +84,9 @@ pimcore.bundle.advancedObjectSearch.searchConfig.conditionEntryPanel = Class.cre
 
                             //after first change, reset data
                             data = {};
+
+                            // fire event that this condition is loaded fully
+                            panel.getPanel().fireEvent("condition:loaded");
                         }
 
                     }.bind(this)

--- a/src/Resources/public/js/searchConfig/conditionGroupPanel.js
+++ b/src/Resources/public/js/searchConfig/conditionGroupPanel.js
@@ -16,6 +16,8 @@ pimcore.registerNS("pimcore.bundle.advancedObjectSearch.searchConfig.conditionGr
 pimcore.bundle.advancedObjectSearch.searchConfig.conditionGroupPanel = Class.create(pimcore.bundle.advancedObjectSearch.searchConfig.conditionAbstractPanel, {
 
     getConditionPanel: function(panel, data) {
+        this.panel = panel;
+
         var niceName = t("bundle_advancedObjectSearch_group");
 
         var myId = Ext.id();
@@ -33,6 +35,14 @@ pimcore.bundle.advancedObjectSearch.searchConfig.conditionGroupPanel = Class.cre
             ]
         });
 
+    },
+
+    /**
+     * legacy method since the parent panel of a condition entry panel can
+     * either be a condition group panel or the condition panel itself
+     */
+    getPanel: function () {
+        return this.panel.getPanel();
     },
 
     getInnerConditionPanel: function(myId, data) {

--- a/src/Resources/public/js/searchConfig/conditionPanel.js
+++ b/src/Resources/public/js/searchConfig/conditionPanel.js
@@ -29,6 +29,14 @@ pimcore.bundle.advancedObjectSearch.searchConfig.conditionPanel = Class.create({
         }
     },
 
+    getPanel: function() {
+        if(!this.panel) {
+            return this.getConditionPanel();
+        }
+
+        return this.panel;
+    },
+
     getConditionPanel: function() {
         var helper = new pimcore.bundle.advancedObjectSearch.searchConfig.conditionPanelContainerBuilder(this.classId, this, "root-panel", this.conditionEntryPanelLayout);
         this.conditionsContainerInner = helper.buildConditionsContainerInner();
@@ -43,13 +51,15 @@ pimcore.bundle.advancedObjectSearch.searchConfig.conditionPanel = Class.create({
             helper.populateConditionsContainerInner(this.data.filters);
         }
 
-        return Ext.create('Ext.panel.Panel',{
+        this.panel = Ext.create('Ext.panel.Panel',{
             border: false,
             items: [
                 this.termField,
                 this.conditionsContainerInner
             ]
         });
+
+        return this.panel;
     },
 
     getSaveData: function() {

--- a/src/Resources/public/js/searchConfig/resultPanel.js
+++ b/src/Resources/public/js/searchConfig/resultPanel.js
@@ -487,17 +487,37 @@ pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel = Class.create(pimc
     getSaveData: function () {
         if (this.grid) {
             var config = this.getGridConfig();
+            var gridColumns = this.grid.getView().getHeaderCt().getGridColumns();
             var columnsConfig = [];
-
             var keys = Object.keys(config.columns);
-            for (var i = 0; i < keys.length; i++) {
 
+            for (var i = 0; i < keys.length; i++) {
                 var entry = config.columns[keys[i]].fieldConfig;
+
                 if (entry) {
                     entry.position = config.columns[keys[i]].position;
+
+                    // store widths according to extjs
+                    if (entry.layout || entry.isOperator) {
+                        for (var j = 0; j < gridColumns.length; j++) {
+                            var column = gridColumns[j];
+
+                            if (column.dataIndex === entry.key) {
+                                if (entry.isOperator) {
+                                    // operator columns need the width directly on the entry
+                                    entry.width = column.width;
+                                } else {
+                                    // basic columns on the layout object
+                                    entry.layout.width = column.width;
+                                }
+
+                                break;
+                            }
+                        }
+                    }
+
                     columnsConfig.push(entry);
                 }
-
             }
 
             config.columns = columnsConfig;

--- a/src/Resources/public/js/searchConfigPanel.js
+++ b/src/Resources/public/js/searchConfigPanel.js
@@ -38,6 +38,11 @@ pimcore.bundle.advancedObjectSearch.searchConfigPanel = Class.create(pimcore.ele
         tabPanel.add(this.tab);
         tabPanel.setActiveItem(this.getTabId());
 
+        // open result panel for saved searches
+        if(this.data.id) {
+            this.tab.setActiveItem(this.resultPanel.getLayout());
+        }
+
         this.tab.on("destroy", function () {
             pimcore.globalmanager.remove(this.getTabId());
         }.bind(this));


### PR DESCRIPTION
This PR fixes #18 by opening the result panel per default for already saved searches, as well as #16 by storing the widths of the columns. Previously the widths were always reset to a default value, since the actual widths were not read from extjs before storing the configuration.