### PR TITLE
updated for pimcore 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,12 @@ advanced_object_search:
     field_definition_adapters:
         newDataTypeName: SERVICE_ID_OF_FIELD_DEFINITION_ADAPTER
 ``` 
+
+
+## Running with Pimcore < 5.4
+With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work 
+with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
+```
+    # rewrite rule for pre pimcore 5.4 core static files
+    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
+``` 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require": {
     "ongr/elasticsearch-dsl": "~5",
-    "pimcore/core-version": ">=5.2.0 <5.4"
+    "pimcore/core-version": ">=5.2.0 <5.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/Resources/public/css/admin.css
+++ b/src/Resources/public/css/admin.css
@@ -13,33 +13,23 @@
 
 
 .pimcore_bundle_advancedObjectSearch_saveAndShare {
-    background: url("/pimcore/static6/img/flat-color-icons/collaboration.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/collaboration.svg") center center no-repeat !important;
 }
 
 .pimcore_bundle_advancedObjectSearch_grid {
-    background: url("/pimcore/static6/img/flat-color-icons/grid.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/grid.svg") center center no-repeat !important;
 }
 
 .pimcore_bundle_advancedObjectSearch_filter {
-    background: url("/pimcore/static6/img/flat-color-icons/filled_filter.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/filled_filter.svg") center center no-repeat !important;
 }
 
 .pimcore_bundle_advancedObjectSearch {
-    background: url("/pimcore/static6/img/flat-color-icons/binoculars.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/binoculars.svg") center center no-repeat !important;
 }
 
-/*.pimcore_bundle_advancedObjectSearch:before {
-    position: absolute;
-    width: 12px;
-    height: 12px;
-    bottom: 0px;
-    left: 0px;
-    content: "";
-    background: url(/pimcore/static6/img/flat-color-icons/opened_folder.svg) center center no-repeat !important;
-}*/
-
 #pimcore_bundle_advancedObjectSearch_toolbar {
-    background-image: url(/pimcore/static6/img/flat-color-icons/binoculars.svg) !important;
+    background-image: url(/bundles/pimcoreadmin/img/flat-color-icons/binoculars.svg) !important;
     filter: grayscale(0%) !important;
     -webkit-filter: grayscale(0%) !important;
     position: relative;
@@ -52,5 +42,5 @@
     bottom: 0px;
     right: 5px;
     content: "";
-    background: url(/pimcore/static6/img/flat-color-icons/settings.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/settings.svg) center center no-repeat !important;
 }

--- a/src/Resources/public/js/searchConfig/resultPanel.js
+++ b/src/Resources/public/js/searchConfig/resultPanel.js
@@ -164,7 +164,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel = Class.create(pimc
             items: [
                 {
                     tooltip: t('open'),
-                    icon: "/pimcore/static6/img/flat-color-icons/cursor.svg",
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/cursor.svg",
                     handler: function (grid, rowIndex) {
                         var data = grid.getStore().getAt(rowIndex);
                         pimcore.helpers.openObject(data.id);


### PR DESCRIPTION
## For running with Pimcore < 5.4
With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
```
    # rewrite rule for pre pimcore 5.4 core static files
    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
``` 