### PR TITLE
bugfix numeric fields

### DIFF
--- a/src/Resources/public/js/searchConfig/fieldConditionPanel/numeric.js
+++ b/src/Resources/public/js/searchConfig/fieldConditionPanel/numeric.js
@@ -19,7 +19,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.fieldConditionPanel.numeric = C
 
         var termFieldValue = "";
         var operatorValue = "";
-        if(isNaN(this.data.filterEntryData)) {
+        if(!isNaN(this.data.filterEntryData)) {
 
             var key = Object.keys(this.data.filterEntryData)[0];
             if(key) {


### PR DESCRIPTION
When selecting a numeric field lots of JS errors are produced. In numeric.js filterEntryData is used when this is null.