### PR TITLE
batch assignment increase limit from 10 to 9999 (same as for CSV export)

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -180,7 +180,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
 
         //get ID list from ES Service
         $data = json_decode($request->get("filter"), true);
-        $results = $service->doFilter($data['classId'], $data['conditions']['filters'], $data['conditions']['fulltextSearchTerm']);
+        $results = $service->doFilter($data['classId'], $data['conditions']['filters'], $data['conditions']['fulltextSearchTerm'], null, 9999);
 
         $ids = $service->extractIdsFromResult($results);
 


### PR DESCRIPTION
The default limit is 10 - therefore the batch assign all action needs an increased limit. For a perfect solution a scrolled search would be needed. For the moment I changed it to 9999 which is the same default limit like for the CSV export.