### PR TITLE
Changed locale to interface

### DIFF
--- a/src/Filter/FieldDefinitionAdapter/Localizedfields.php
+++ b/src/Filter/FieldDefinitionAdapter/Localizedfields.php
@@ -23,7 +23,7 @@ use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\Joining\NestedQuery;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Service\Locale;
+use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Tool;
 
 class Localizedfields extends DefaultAdapter implements IFieldDefinitionAdapter {
@@ -38,7 +38,7 @@ class Localizedfields extends DefaultAdapter implements IFieldDefinitionAdapter 
      */
     protected $localeService;
 
-    public function __construct(Service $service, Locale $locale = null)
+    public function __construct(Service $service, LocaleServiceInterface $locale = null)
     {
         parent::__construct($service);
 


### PR DESCRIPTION
If pimcore LocaleService is decorated, the advanced object search does not work anymore.
Therefore we needs to use LocaleServiceInterface here instead of Locale class.

How to reproduce:
1. Create LocaleService Decorator
2. Run index command: bin/console advanced-object-search:re-index

Exception:

Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 2 passed to AdvancedObjectSearchBundle\Filter\FieldDefinitionAdapter\Localizedfields::__construct() must be an instance of Pimcore\Localization\LocaleService or null, instance of MyBundle\Decorator\LocaleDecorator given, called in /private/var/www/htdocs/var/cache/dev/ContainerDhozf2p/appDevDebugProjectContainer.php on line 3744 in /private/var/www/htdocs/vendor/pimcore/advanced-object-search/src/Filter/FieldDefinitionAdapter/Localizedfields.php:41