### PR TITLE
Batch update field definition fix when definition changed since last save

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -380,7 +380,11 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
                     if(!$column["isOperator"]) {
                         $fieldDefinition = $classDefinition->getFieldDefinition($column['key']);
                         if($fieldDefinition) {
+                            $width = isset($column["layout"]["width"]) ? $column["layout"]["width"] : null;
                             $column["layout"] = json_decode(json_encode($fieldDefinition), true);
+                            if($width) {
+                                $column["layout"]["width"] = $width;
+                            }
                         }
                     }
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -371,11 +371,19 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         $savedSearch = SavedSearch::getById($id);
         if($savedSearch) {
             $config = json_decode($savedSearch->getConfig(), true);
+            $classDefinition = DataObject\ClassDefinition::getById($config['classId']);
 
             if(!empty($config["gridConfig"]["columns"])) {
                 $helperColumns = [];
 
                 foreach ($config["gridConfig"]["columns"] as $column) {
+                    if(!$column["isOperator"]) {
+                        $fieldDefinition = $classDefinition->getFieldDefinition($column['key']);
+                        if($fieldDefinition) {
+                            $column["layout"] = json_decode(json_encode($fieldDefinition), true);
+                        }
+                    }
+
                     if (!DataObject\Service::isHelperGridColumnConfig($column["key"])) {
                         continue;
                     }


### PR DESCRIPTION
As the column definitions are stored directly in the config json the layout definition never get's updated. This is especially relevant for batch append of (multi)select fields as the select options will not be updated automatically.

This pull request solves the problem by refreshing the field definition via the Pimcore API.