### PR TITLE
Batch update field definition fix when definition changed since last save

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -381,7 +381,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
             if(!empty($config["gridConfig"]["columns"])) {
                 $helperColumns = [];
 
-                foreach ($config["gridConfig"]["columns"] as $column) {
+                foreach ($config["gridConfig"]["columns"] as &$column) {
                     if(!$column["isOperator"]) {
                         $fieldDefinition = $classDefinition->getFieldDefinition($column['key']);
                         if($fieldDefinition) {


### PR DESCRIPTION
This is a follow up task to #41. It does not work anymore, the column needs to be a reference as otherwise it's value is not changed.