### PR TITLE
[Core fields] Fixed condition, added support to Pimcore 6.4.x

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -603,7 +603,7 @@ class Service {
 
                 $considerInheritance = $objectClass->getAllowInherit();
 
-                if($fieldDefinition === false) {
+                if(! $fieldDefinition instanceof ClassDefinition\Data) {
                     $fieldName = $filterEntryObject->getFieldname();
                     $fieldDefinition = $this->getCoreFieldDefinition(
                         $fieldName,


### PR DESCRIPTION
`\Pimcore\Model\DataObject\ClassDefinition::getFieldDefinition`  has a change in return types. 
Instead of `false` when field definition was not found, returns `null`.