### PR TITLE
Fixed typo in the definition of allowedTypes

### DIFF
--- a/src/Filter/FieldDefinitionAdapter/ManyToManyObjectRelation.php
+++ b/src/Filter/FieldDefinitionAdapter/ManyToManyObjectRelation.php
@@ -39,7 +39,7 @@ class ManyToManyObjectRelation extends ManyToOneRelation implements IFieldDefini
     {
         $allowedTypes = [];
         $allowedClasses = [];
-        $allowedTypes[] = ["objects", "object_ids"];
+        $allowedTypes[] = ["object", "object_ids"];
         $allowedTypes[] = ["object_filter", "object_filter"];
 
         foreach($this->fieldDefinition->getClasses() as $class) {


### PR DESCRIPTION
`manyToManyObjectRelation` by typeField: `object_ids` correctly filter by relation ids, but when I save filters and reopen it, `typeField` hasn`t selected value. 

I found that below section always set as value `object` when any id was saved:
https://github.com/pimcore/advanced-object-search/blob/c81bf2fb28049cf54a866ae822461fd9afc08545/src/Resources/public/js/searchConfig/fieldConditionPanel/manyToManyOne.js#L112-L118