### PR TITLE
Register the maintenance job for update queue processing in Pimcore 6

### DIFF
--- a/src/EventListener/IndexUpdateListener.php
+++ b/src/EventListener/IndexUpdateListener.php
@@ -19,11 +19,9 @@ namespace AdvancedObjectSearchBundle\EventListener;
 use AdvancedObjectSearchBundle\Service;
 use Pimcore\Event\Model\DataObject\ClassDefinitionEvent;
 use Pimcore\Event\Model\DataObjectEvent;
-use Pimcore\Event\System\MaintenanceEvent;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\Schedule\Maintenance\Job;
 
 class IndexUpdateListener
 {
@@ -71,13 +69,4 @@ class IndexUpdateListener
             Logger::err($e);
         }
     }
-
-    public function registerMaintenanceJob(MaintenanceEvent $maintenanceEvent) {
-        $maintenanceEvent->getManager()->registerJob(new Job(get_class($this), [$this, "maintenance"]));
-    }
-
-    public function maintenance() {
-        $this->service->processUpdateQueue(500);
-    }
-
 }

--- a/src/Maintenance/UpdateQueueProcessor.php
+++ b/src/Maintenance/UpdateQueueProcessor.php
@@ -17,7 +17,9 @@ namespace AdvancedObjectSearchBundle\Maintenance;
 
 
 use AdvancedObjectSearchBundle\Service;
+use Pimcore\Event\System\MaintenanceEvent;
 use Pimcore\Maintenance\TaskInterface;
+use Pimcore\Model\Schedule\Maintenance\Job;
 
 class UpdateQueueProcessor implements TaskInterface
 {
@@ -29,6 +31,14 @@ class UpdateQueueProcessor implements TaskInterface
     public function __construct(Service $service)
     {
         $this->service = $service;
+    }
+
+    /**
+     * Note: When Pimcore v5 support is dropped, this can be removed.
+     */
+    public function registerMaintenanceJob(MaintenanceEvent $maintenanceEvent)
+    {
+        $maintenanceEvent->getManager()->registerJob(new Job(get_class($this), [$this, "execute"]));
     }
 
     public function execute()

--- a/src/Maintenance/UpdateQueueProcessor.php
+++ b/src/Maintenance/UpdateQueueProcessor.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+
+namespace AdvancedObjectSearchBundle\Maintenance;
+
+
+use AdvancedObjectSearchBundle\Service;
+use Pimcore\Maintenance\TaskInterface;
+
+class UpdateQueueProcessor implements TaskInterface
+{
+    /**
+     * @var Service
+     */
+    protected $service;
+
+    public function __construct(Service $service)
+    {
+        $this->service = $service;
+    }
+
+    public function execute()
+    {
+        $this->service->processUpdateQueue(500);
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -47,6 +47,10 @@ services:
             - { name: kernel.event_listener, event: pimcore.class.postDelete, method: deleteIndex }
             - { name: kernel.event_listener, event: pimcore.system.maintenance, method: registerMaintenanceJob }
 
+    AdvancedObjectSearchBundle\Maintenance\UpdateQueueProcessor:
+        tags:
+            - { name: pimcore.maintenance.task, type: advancedobjectsearch_update_queue }
+
     bundle.advanced_object_search.filter_locator:
         class: Symfony\Component\DependencyInjection\ServiceLocator
         tags: ['container.service_locator']

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -45,11 +45,12 @@ services:
             - { name: kernel.event_listener, event: pimcore.dataobject.preDelete, method: deleteObject }
             - { name: kernel.event_listener, event: pimcore.class.postUpdate, method: updateMapping }
             - { name: kernel.event_listener, event: pimcore.class.postDelete, method: deleteIndex }
-            - { name: kernel.event_listener, event: pimcore.system.maintenance, method: registerMaintenanceJob }
 
     AdvancedObjectSearchBundle\Maintenance\UpdateQueueProcessor:
         tags:
             - { name: pimcore.maintenance.task, type: advancedobjectsearch_update_queue }
+            # Note: When Pimcore v5 support is dropped, this can be removed.
+            - { name: kernel.event_listener, event: pimcore.system.maintenance, method: registerMaintenanceJob }
 
     bundle.advanced_object_search.filter_locator:
         class: Symfony\Component\DependencyInjection\ServiceLocator


### PR DESCRIPTION
While upgrading to Pimcore 6, I noticed that this bundle still uses the old way to register its maintenance job, which was deprecated in Pimcore v5.8 with https://github.com/pimcore/pimcore/pull/3895 and removed in v6.0 with https://github.com/pimcore/pimcore/commit/9d354b281c1269e4ab1f1fa9192a660bb57c69fa. 

See also this line from the v5 to v6 upgrade notes:
> Maintenance Job: Removed event pimcore.system.maintenance and the old way using Job to add custom tasks. Please instead register the maintenance task as a service

---

Note that, as this bundle still supports Pimcore >=5.5.0, we need both ways at the moment.

---

Question:
Are v1 and/or v2 of this Bundle still maintained? (I hope so, because we're still using Elasticsearch v5 which seems only be supported by v1 of this Bundle.)

In that case I'd rebase and retarget the PR (or send another one per branch if this is more desired).