### PR TITLE
Upgrade `ongr/elasticsearch-dsl` to `v6`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "sort-packages": true
   },
   "require": {
-    "ongr/elasticsearch-dsl": "^5.0.5",
+    "ongr/elasticsearch-dsl": "^6.0.1",
     "pimcore/pimcore": ">=5.5.0 <6.7"
   },
   "autoload": {


### PR DESCRIPTION
The readme says that this package (only) supports ElasticSearch 6. 

According to the readme of [`ongr/elasticsearch-dsl`](https://github.com/ongr-io/ElasticsearchDSL/blob/master/README.md#version-matrix) the `v6` of this library is needed for ElasticSearch 6.

So I think the dependency should be upgraded.