### PR TITLE
Set proper path to config in Installer

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -18,7 +18,7 @@ class Installer extends MigrationInstaller
         if (! file_exists(PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY . "/advancedobjectsearch")) {
             \Pimcore\File::mkdir(PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY . "/advancedobjectsearch");
             copy(
-                __DIR__ . "/../Resources/install/config.php",
+                __DIR__ . "/Resources/install/config.php",
                 PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY . "/advancedobjectsearch/config.php"
             );
         }


### PR DESCRIPTION
Hi,
during installation module there is a problem with copy config file - path is wrong. 

` [ERROR] Warning: copy(/var/www/vendor/pimcore/advanced-object-search/src/../Resources/install/config.php): failed to   
         open stream: No such file or directory  `