### PR TITLE
Make batch prepare working with current Pimcore versions

### DIFF
--- a/src/Resources/public/js/searchConfig/resultPanel.js
+++ b/src/Resources/public/js/searchConfig/resultPanel.js
@@ -392,7 +392,27 @@ pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel = Class.create(pimc
         menu.showAt(e.pageX, e.pageY);
     },
 
-    batchPrepare: function (columnIndex, onlySelected, append, remove) {
+    batchPrepare: function (column, onlySelected, append, remove) {
+
+        var columnIndex;
+        if(typeof column != 'object') {
+            columnIndex = column;
+        } else {
+            var dataIndexName = column.dataIndex;
+            var gridColumns = this.grid.getColumns();
+            columnIndex = -1;
+            for (let i = 0; i < gridColumns.length; i++) {
+                let dataIndex = gridColumns[i].dataIndex;
+                if (dataIndex == dataIndexName) {
+                    columnIndex = i;
+                    break;
+                }
+            }
+            if (columnIndex < 0) {
+                return;
+            }
+        }
+
         // no batch for system properties
         if (this.systemColumns.indexOf(this.grid.getColumns()[columnIndex].dataIndex) > -1) {
             return;


### PR DESCRIPTION
In this PR the first parameter of Pimcore's batchPrepare Method changed to an object. Therefore the advanced object search does not work with current Pimcore versions: https://github.com/pimcore/pimcore/pull/6181

With this PR it should work for the current version and for older versions too.