### PR TITLE
Improve error message when config file not found

### DIFF
--- a/src/AdvancedObjectSearchBundle.php
+++ b/src/AdvancedObjectSearchBundle.php
@@ -77,7 +77,7 @@ class AdvancedObjectSearchBundle extends AbstractPimcoreBundle
             }
 
             if (!$file) {
-                throw new \Exception($file . " doesn't exist");
+                throw new \Exception("Configuration file could not be found in any of the following locations: " . implode(', ', $pathsToCheck));
             }
 
             self::$config = include $file;


### PR DESCRIPTION
if `$file` is null, it would show 

    In AdvancedObjectSearchBundle.php line 81:

      doesn't exist

which is not utterly helpful. With this PR I'm suggesting an alternative error message.