### PR TITLE
Add overflow scroller for secondary tbar

### DIFF
--- a/src/Resources/public/js/searchConfig/resultPanel.js
+++ b/src/Resources/public/js/searchConfig/resultPanel.js
@@ -278,6 +278,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel = Class.create(pimc
                     {
                         xtype: 'toolbar',
                         dock: 'top',
+                        overflowHandler: 'scroller',
                         items: secondaryTbar
                     }
                 );


### PR DESCRIPTION
We have this scroller already for the primary tbar (which can be used to embed customized filters). This PR adds the same for the secondary tbar.