### PR TITLE
Remove from queue if object no longer exists

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -516,6 +516,9 @@ class Service {
                 $object = Concrete::getById($objectId);
                 if($object) {
                     $this->doUpdateIndexData($object);
+                } else {
+                    // Object no longer exists, remove from queue
+                    $db->executeQuery("DELETE FROM " . Installer::QUEUE_TABLE_NAME . " WHERE o_id = ?", [$objectId]);
                 }
             }
             return count($entries);


### PR DESCRIPTION
Hi! Got stuck with a "Currently updating search index" status that never went away. Found from:

    SELECT * FROM bundle_advancedobjectsearch_update_queue WHERE in_queue = 1

that the queue contained some deleted objects. Seems like Advanced Object Search will just continue to check for their existence every time, without ever removing them from the queue. Attaching a proposed fix.
