### PR TITLE
Add filter for table

### DIFF
--- a/src/AdvancedObjectSearchBundle.php
+++ b/src/AdvancedObjectSearchBundle.php
@@ -144,6 +144,7 @@ class AdvancedObjectSearchBundle extends AbstractPimcoreBundle
             '/bundles/advancedobjectsearch/js/searchConfig/fieldConditionPanel/date.js',
             '/bundles/advancedobjectsearch/js/searchConfig/fieldConditionPanel/time.js',
             '/bundles/advancedobjectsearch/js/searchConfig/fieldConditionPanel/quantityValue.js',
+            '/bundles/advancedobjectsearch/js/searchConfig/fieldConditionPanel/table.js',
             '/bundles/advancedobjectsearch/js/portlet/advancedObjectSearch.js'
         ];
     }

--- a/src/Filter/FieldDefinitionAdapter/Table.php
+++ b/src/Filter/FieldDefinitionAdapter/Table.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace AdvancedObjectSearchBundle\Filter\FieldDefinitionAdapter;
+
+use AdvancedObjectSearchBundle\Filter\FieldSelectionInformation;
+use AdvancedObjectSearchBundle\Filter\FilterEntry;
+use AdvancedObjectSearchBundle\Service;
+use ONGR\ElasticsearchDSL\BuilderInterface;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\FullText\QueryStringQuery;
+use ONGR\ElasticsearchDSL\Query\Joining\NestedQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\ExistsQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\Concrete;
+
+class Table implements IFieldDefinitionAdapter
+{
+
+    /**
+     * @url https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html
+     *
+     * The value for ignore_above is the character count, but Lucene counts bytes. If you use UTF-8 text with
+     * many non-ASCII characters, you may want to set the limit to 32766 / 4 = 8191 since UTF-8 characters may
+     * occupy at most 4 bytes.
+     */
+    const IGNORE_ABOVE = 8191;
+
+    /**
+     * field type for search frontend
+     *
+     * @var string
+     */
+    protected $fieldType = "table";
+
+    /**
+     * @var Data
+     */
+    protected $fieldDefinition;
+
+    /**
+     * @var bool
+     */
+    protected $considerInheritance;
+
+    /**
+     * @var string
+     */
+    protected $column;
+
+    /**
+     * @var Service
+     */
+    protected $service;
+
+    /**
+     * Table constructor.
+     * @param Service $service
+     */
+    public function __construct(Service $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @param Data $fieldDefinition
+     */
+    public function setFieldDefinition(Data $fieldDefinition)
+    {
+        $this->fieldDefinition = $fieldDefinition;
+    }
+
+    /**
+     * @param bool $considerInheritance
+     */
+    public function setConsiderInheritance(bool $considerInheritance)
+    {
+        $this->considerInheritance = $considerInheritance;
+    }
+
+    /**
+     * @return array
+     */
+    public function getESMapping()
+    {
+        $mapping = [
+            'type' => 'keyword'
+        ];
+
+        if ($this->isColumnConfigActivated()) {
+            $mapping['type'] = 'nested';
+            foreach ($this->fieldDefinition->columnConfig as $columnConfig) {
+                $mapping['properties'][$columnConfig['key']] = ['type' => 'keyword'];
+            }
+        } else {
+            // https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html
+            $mapping['ignore_above'] = self::IGNORE_ABOVE;
+        }
+
+        if ($this->considerInheritance) {
+            $inheritanceMapping = [
+                $this->fieldDefinition->getName(),
+                [
+                    'properties' => [
+                        self::ES_MAPPING_PROPERTY_STANDARD => $mapping,
+                        self::ES_MAPPING_PROPERTY_NOT_INHERITED => $mapping
+                    ]
+                ]
+            ];
+
+            return $inheritanceMapping;
+        } else {
+            return [
+                $this->fieldDefinition->getName(),
+                $mapping
+            ];
+        }
+    }
+
+    /**
+     * @param $object
+     * @param bool $ignoreInheritance
+     * @return string
+     */
+    protected function doGetIndexDataValue($object, $ignoreInheritance = false)
+    {
+        $inheritanceBackup = null;
+        if ($ignoreInheritance) {
+            $inheritanceBackup = AbstractObject::getGetInheritedValues();
+            AbstractObject::setGetInheritedValues(false);
+        }
+
+        $value = $this->fieldDefinition->getForWebserviceExport($object);
+        if ($this->isColumnConfigActivated()) {
+            // When saving an object the array doesnt have named keys, so first get data for resource
+            // and then get the data from resource. This way we have named keys in the data array
+            $value = $this->fieldDefinition->getDataFromResource($this->fieldDefinition->getDataForResource($value,
+                $object));
+        }
+
+        if ($ignoreInheritance) {
+            AbstractObject::setGetInheritedValues($inheritanceBackup);
+        }
+
+        if (!$this->isColumnConfigActivated() && is_array($value)) {
+            return json_encode($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param Concrete $object
+     * @return mixed
+     */
+    public function getIndexData($object)
+    {
+
+        $value = $this->doGetIndexDataValue($object, false);
+
+        if ($this->considerInheritance) {
+            $notInheritedValue = $this->doGetIndexDataValue($object, true);
+
+            $returnValue = null;
+            if ($value) {
+                $returnValue[self::ES_MAPPING_PROPERTY_STANDARD] = $value;
+            }
+
+            if ($notInheritedValue) {
+                $returnValue[self::ES_MAPPING_PROPERTY_NOT_INHERITED] = $notInheritedValue;
+            }
+
+            return $returnValue;
+
+        } else {
+
+            if ($value) {
+                return $value;
+            } else {
+                return null;
+            }
+        }
+    }
+
+
+    protected function buildQueryFieldPostfix($ignoreInheritance = false)
+    {
+        $postfix = "";
+
+        if ($this->considerInheritance) {
+            if ($ignoreInheritance) {
+                $postfix = "." . self::ES_MAPPING_PROPERTY_NOT_INHERITED;
+            } else {
+                $postfix = "." . self::ES_MAPPING_PROPERTY_STANDARD;
+            }
+        }
+
+        return $postfix;
+    }
+
+
+    /**
+     * @param $fieldFilter
+     *
+     * @param bool $ignoreInheritance
+     * @param string $path
+     * @return BuilderInterface
+     */
+    public function getQueryPart($fieldFilter, $ignoreInheritance = false, $path = "")
+    {
+        $term = $fieldFilter['term'];
+        $fieldsPath = $path . $this->fieldDefinition->getName() . $this->buildQueryFieldPostfix($ignoreInheritance);
+
+        // Search in nested field
+        if ($this->isColumnConfigActivated()) {
+            $boolQuery = new BoolQuery();
+
+            if (!empty($fieldFilter['column'])) {
+                $innerBoolQuery = new BoolQuery();
+                $innerBoolQuery->add(new TermQuery($fieldsPath . "." . $fieldFilter['column'], $term));
+                $boolQuery->add(new NestedQuery($fieldsPath, $innerBoolQuery), BoolQuery::SHOULD);
+            } else {
+                foreach ($this->fieldDefinition->columnConfig as $column) {
+                    $innerBoolQuery = new BoolQuery();
+                    $innerBoolQuery->add(new TermQuery($fieldsPath . "." . $column['key'], $term));
+
+                    $boolQuery->add(new NestedQuery($fieldsPath, $innerBoolQuery), BoolQuery::SHOULD);
+                }
+                $boolQuery->addParameter("minimum_should_match", 1);
+            }
+
+            return $boolQuery;
+        }
+
+        return new QueryStringQuery($term, ["fields" => [$fieldsPath]]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFieldSelectionInformation()
+    {
+        $columnConfig = [];
+        if ($this->isColumnConfigActivated()) {
+            foreach ($this->fieldDefinition->columnConfig as $column) {
+                $columnConfig[] = $column;
+            }
+        }
+
+        return [
+            new FieldSelectionInformation(
+                $this->fieldDefinition->getName(),
+                $this->fieldDefinition->getTitle(),
+                $this->fieldType,
+                [
+                    'operators' => [
+                        BoolQuery::MUST,
+                        BoolQuery::SHOULD,
+                        BoolQuery::MUST_NOT,
+                        FilterEntry::EXISTS,
+                        FilterEntry::NOT_EXISTS
+                    ],
+                    'classInheritanceEnabled' => $this->considerInheritance,
+                    'columnConfigActivated' => $this->isColumnConfigActivated(),
+                    'columnConfig' => $columnConfig
+                ]
+            )
+        ];
+    }
+
+    protected function isColumnConfigActivated()
+    {
+        return (property_exists($this->fieldDefinition, 'columnConfigActivated')
+            && $this->fieldDefinition->columnConfigActivated === true);
+    }
+}

--- a/src/Filter/FieldDefinitionAdapter/Table.php
+++ b/src/Filter/FieldDefinitionAdapter/Table.php
@@ -257,9 +257,7 @@ class Table implements IFieldDefinitionAdapter
                     'operators' => [
                         BoolQuery::MUST,
                         BoolQuery::SHOULD,
-                        BoolQuery::MUST_NOT,
-                        FilterEntry::EXISTS,
-                        FilterEntry::NOT_EXISTS
+                        BoolQuery::MUST_NOT
                     ],
                     'classInheritanceEnabled' => $this->considerInheritance,
                     'columnConfigActivated' => $this->isColumnConfigActivated(),

--- a/src/Resources/config/pimcore/config.yml
+++ b/src/Resources/config/pimcore/config.yml
@@ -23,6 +23,7 @@ advanced_object_search:
         select: 'bundle.advanced_object_search.filter.select'
         time: 'bundle.advanced_object_search.filter.time'
         user: 'bundle.advanced_object_search.filter.user'
+        table: 'bundle.advanced_object_search.filter.table'
 
         # legacy mappings
         href: 'AdvancedObjectSearchBundle\Filter\FieldDefinitionAdapter\ManyToOneRelation'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -148,6 +148,10 @@ services:
         class: AdvancedObjectSearchBundle\Filter\FieldDefinitionAdapter\User
         shared: false
 
+    bundle.advanced_object_search.filter.table:
+        class: AdvancedObjectSearchBundle\Filter\FieldDefinitionAdapter\Table
+        shared: false
+
     # auto-register all commands as services
     AdvancedObjectSearchBundle\Command\ProcessUpdateQueueCommand: ~
     AdvancedObjectSearchBundle\Command\ReindexCommand: ~

--- a/src/Resources/public/js/searchConfig/fieldConditionPanel/table.js
+++ b/src/Resources/public/js/searchConfig/fieldConditionPanel/table.js
@@ -1,0 +1,166 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+
+pimcore.registerNS("pimcore.bundle.advancedObjectSearch.searchConfig.fieldConditionPanel.table");
+pimcore.bundle.advancedObjectSearch.searchConfig.fieldConditionPanel.table = Class.create({
+
+    fieldSelectionInformation: null,
+    data: {},
+    termField: null,
+    columnField: null,
+    operatorField: null,
+    inheritanceField: null,
+    classId: null,
+
+    initialize: function (fieldSelectionInformation, data, classId) {
+        this.fieldSelectionInformation = fieldSelectionInformation;
+        this.classId = classId;
+        if (data) {
+            this.data = data;
+        }
+    },
+
+    getConditionPanel: function () {
+        this.termField = Ext.create('Ext.form.field.Text',
+            {
+                fieldLabel: t("bundle_advancedObjectSearch_term"),
+                width: 400,
+                value: this.data.filterEntryData
+            }
+        );
+
+        this.inheritanceField = Ext.create('Ext.form.field.Checkbox',
+            {
+                fieldLabel: t("bundle_advancedObjectSearch_ignoreInheritance"),
+                value: this.data.ignoreInheritance,
+                hidden: !this.fieldSelectionInformation.context.classInheritanceEnabled
+            }
+        );
+
+        var termPanel = Ext.create('Ext.panel.Panel', {});
+        termPanel.add(this.termField);
+        termPanel.add(this.inheritanceField);
+
+        return Ext.create('Ext.panel.Panel', {
+            items: [
+                {
+                    xtype: 'panel',
+                    layout: 'hbox',
+                    style: "padding-bottom: 10px",
+                    items: [
+                        this.getColumnCombobox(this.data.column),
+                    ]
+                },
+                {
+                    xtype: 'panel',
+                    layout: 'hbox',
+                    style: "padding-bottom: 10px",
+                    items: [
+                        this.getOperatorCombobox(this.data.operator)
+                    ]
+                },
+                {
+                    xtype: 'panel',
+                    layout: 'hbox',
+                    style: "padding-bottom: 10px",
+                    items: [
+                        this.termField,
+                        this.inheritanceField
+                    ]
+                },
+            ]
+        });
+    },
+
+    getColumnCombobox: function (value) {
+        if (this.fieldSelectionInformation.context.columnConfigActivated) {
+            var columnConfig = Ext.create('Ext.data.Store', {
+                fields: ['fieldName', 'fieldLabel'],
+                data: this.fieldSelectionInformation.context.columnConfig.map(function (column) {
+                    return {
+                        fieldName: column.key,
+                        fieldLabel: column.label
+                    };
+                })
+            });
+
+            this.columnField = Ext.create('Ext.form.ComboBox',
+                {
+                    fieldLabel: t("bundle_advancedsearch_table_colum_config"),
+                    store: columnConfig,
+                    value: value,
+                    queryMode: 'local',
+                    width: 300,
+                    valueField: 'fieldName',
+                    displayField: 'fieldLabel'
+                }
+            );
+
+            return this.columnField;
+        }
+    },
+
+    getOperatorCombobox: function (value) {
+        var operators = Ext.create('Ext.data.Store', {
+            fields: ['fieldName', 'fieldLabel'],
+            data: this.fieldSelectionInformation.context.operators.map(function (operator) {
+                return {
+                    fieldName: operator,
+                    fieldLabel: t('bundle_advancedsearch_operator_' + operator)
+                };
+            })
+        });
+
+        this.operatorField = Ext.create('Ext.form.ComboBox',
+            {
+                fieldLabel: t("bundle_advancedObjectSearch_operator"),
+                store: operators,
+                value: value,
+                queryMode: 'local',
+                width: 300,
+                valueField: 'fieldName',
+                displayField: 'fieldLabel',
+                listeners: {
+                    change: function (item, newValue, oldValue, eOpts) {
+
+                        if (this.termField) {
+                            this.termField.setDisabled(newValue == "exists" || newValue == "not_exists");
+                        }
+
+                    }.bind(this)
+                }
+            }
+        );
+
+        return this.operatorField;
+    },
+
+    getFilterValues: function () {
+        var subValue = {};
+        subValue.term = this.termField.getValue();
+
+        if (this.fieldSelectionInformation.context.columnConfigActivated) {
+            subValue.column = this.columnField.getValue();
+        }
+
+        return {
+            fieldname: this.fieldSelectionInformation.fieldName,
+            filterEntryData: subValue,
+            operator: this.operatorField.getValue(),
+            ignoreInheritance: this.inheritanceField.getValue()
+        };
+    }
+
+
+});

--- a/src/Resources/translations/admin.en.yml
+++ b/src/Resources/translations/admin.en.yml
@@ -47,3 +47,4 @@ bundle_advancedsearch_operator_must: must
 bundle_advancedsearch_operator_must_not: must not
 bundle_advancedsearch_operator_should: should
 bundle_advancedObjectSearch_roles: Roles
+bundle_advancedsearch_table_colum_config: Column


### PR DESCRIPTION
I have added a filter for tables, in this filter i have made a difference between tables with and without column config. When there is a column config, a nested mapping will be created with the columns. If no column config is set, the property `ignore_above` is set and the data is saved as JSON string.

Search condition is added so you can search in a specific column. 

Fixes #105 