### PR TITLE
Added events for subscription event listeners on save or delete saved search.

### DIFF
--- a/src/Event/SavedSearchEvent.php
+++ b/src/Event/SavedSearchEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AdvancedObjectSearchBundle\Event;
+
+use AdvancedObjectSearchBundle\Model\SavedSearch;
+use Symfony\Component\EventDispatcher\Event;
+
+class SavedSearchEvent extends Event
+{
+    /**
+     * @var SavedSearch
+     */
+    protected $search;
+
+    public function __construct(SavedSearch $search)
+    {
+        $this->search = $search;
+    }
+
+    /**
+     * @return Search
+     */
+    public function getSavedSearch(): SavedSearch
+    {
+        return $this->search;
+    }
+}

--- a/src/Event/SavedSearchEvents.php
+++ b/src/Event/SavedSearchEvents.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AdvancedObjectSearchBundle\Event;
+
+final class SavedSearchEvents
+{
+    /**
+     * @Event("AdvancedObjectSearchBundle\Event\SavedSearchEvent")
+     */
+    const PRE_SAVE = "advanced_object_search.saved_search.preSave";
+
+    /**
+     * @Event("AdvancedObjectSearchBundle\Event\SavedSearchEvent")
+     */
+    const POST_SAVE = "advanced_object_search.saved_search.postSave";
+
+    /**
+     * @Event("AdvancedObjectSearchBundle\Event\SavedSearchEvent")
+     */
+    const PRE_DELETE = "advanced_object_search.saved_search.preDelete";
+
+    /**
+     * @Event("AdvancedObjectSearchBundle\Event\SavedSearchEvent")
+     */
+    const POST_DELETE = "advanced_object_search.saved_search.postDelete";
+}

--- a/src/Model/SavedSearch.php
+++ b/src/Model/SavedSearch.php
@@ -15,6 +15,8 @@
 
 namespace AdvancedObjectSearchBundle\Model;
 
+use AdvancedObjectSearchBundle\Event\SavedSearchEvents;
+use AdvancedObjectSearchBundle\Event\SavedSearchEvent;
 use Pimcore\Model;
 
 class SavedSearch extends Model\AbstractModel
@@ -87,10 +89,22 @@ class SavedSearch extends Model\AbstractModel
         }
     }
 
-
     public function save()
     {
+        \Pimcore::getEventDispatcher()->dispatch(SavedSearchEvents::PRE_SAVE, new SavedSearchEvent($this));
+
         $this->getDao()->save();
+
+        \Pimcore::getEventDispatcher()->dispatch(SavedSearchEvents::POST_SAVE, new SavedSearchEvent($this));
+    }
+
+    public function delete()
+    {
+        \Pimcore::getEventDispatcher()->dispatch(SavedSearchEvents::PRE_DELETE, new SavedSearchEvent($this));
+        
+        $this->getDao()->delete();
+
+        \Pimcore::getEventDispatcher()->dispatch(SavedSearchEvents::POST_DELETE, new SavedSearchEvent($this));
     }
 
     /**


### PR DESCRIPTION
Hi!

It's small adjustment and adds dispatch event for register listeners on save and delete Saved search.
In this case. now possible to use SavedSearch for another Bundles and handle changes in Events.

Please review, 