### PR TITLE
[Bug]: Save And Share does not work for non Admins

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -264,7 +264,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         $savedSearch->setDescription($data->settings->description);
         $savedSearch->setCategory($data->settings->category);
         $savedSearch->setSharedUserIds(array_merge($data->settings->shared_users, $data->settings->shared_roles));
-        $savedSearch->setShareGlobally($data->settings->share_globally && $this->getAdminUser()->isAdmin());
+        $savedSearch->setShareGlobally($this->getAdminUser()->isAdmin() && $data->settings->share_globally);
 
         $config = ['classId' => $data->classId, 'gridConfig' => $data->gridConfig, 'conditions' => $data->conditions];
         $savedSearch->setConfig(json_encode($config));


### PR DESCRIPTION
Fixes #154 

Notes: caused by this [Share Globally](https://github.com/pimcore/advanced-object-search/blob/1c83727f649c692cdceb2b3b5dcaf42a7ea2e25d/src/Resources/public/js/searchConfigPanel.js#L200-L208) field only appearing and saved when is admin in the frontend. 