### PR TITLE
[Task]: Always use flat white binoculars icon 

### DIFF
--- a/src/Resources/public/css/admin.css
+++ b/src/Resources/public/css/admin.css
@@ -29,10 +29,6 @@
 }
 
 .pimcore_bundle_nav_icon_advancedObjectSearch {
-    background: url("/bundles/pimcoreadmin/img/flat-color-icons/binoculars.svg") center center no-repeat !important;
-}
-
-.pimcore_version_6 .pimcore_bundle_nav_icon_advancedObjectSearch, .pimcore_version_10 .pimcore_bundle_nav_icon_advancedObjectSearch {
     background: url("/bundles/pimcoreadmin/img/flat-white-icons/binoculars.svg") center center no-repeat !important;
 }
 


### PR DESCRIPTION
Resolves https://github.com/pimcore/advanced-object-search/issues/187

Simplified by not specifying the version anymore, since we do not support any Pimcore version prior 6.