### PR TITLE
[Task]: Quote `name` and `description`

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -20,6 +20,7 @@ use AdvancedObjectSearchBundle\Event\FilterListingEvent;
 use AdvancedObjectSearchBundle\Model\SavedSearch;
 use AdvancedObjectSearchBundle\Service;
 use Pimcore\Bundle\AdminBundle\Helper\QueryParams;
+use Pimcore\Db;
 use Pimcore\Model\DataObject;
 use Pimcore\Tool;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -313,6 +314,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         $offset = $offset ? $offset : 0;
         $limit = $limit ? $limit : 50;
 
+        $db = Db::get();
         $searcherList = new SavedSearch\Listing();
         $conditionParts = [];
         $conditionParams = [];
@@ -328,8 +330,8 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         //filter for query
         if (!empty($query)) {
             $conditionParts[] = sprintf('(%s LIKE ? OR %s LIKE ? OR category LIKE ?)',
-                $searcherList->quoteIdentifier('name'),
-                $searcherList->quoteIdentifier('description')
+                $db->quoteIdentifier('name'),
+                $db->quoteIdentifier('description')
             );
             $conditionParams[] = '%' . $query . '%';
             $conditionParams[] = '%' . $query . '%';

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -329,9 +329,10 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
 
         //filter for query
         if (!empty($query)) {
-            $conditionParts[] = sprintf('(%s LIKE ? OR %s LIKE ? OR category LIKE ?)',
+            $conditionParts[] = sprintf('(%s LIKE ? OR %s LIKE ? OR %s LIKE ?)',
                 $db->quoteIdentifier('name'),
-                $db->quoteIdentifier('description')
+                $db->quoteIdentifier('description'),
+                $db->quoteIdentifier('category')
             );
             $conditionParams[] = '%' . $query . '%';
             $conditionParams[] = '%' . $query . '%';

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -327,7 +327,10 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
 
         //filter for query
         if (!empty($query)) {
-            $conditionParts[] = '(name LIKE ? OR description LIKE ? OR category LIKE ?)';
+            $conditionParts[] = sprintf('(%s LIKE ? OR %s LIKE ? OR category LIKE ?)',
+                $searcherList->quoteIdentifier('name'),
+                $searcherList->quoteIdentifier('description')
+            );
             $conditionParams[] = '%' . $query . '%';
             $conditionParams[] = '%' . $query . '%';
             $conditionParams[] = '%' . $query . '%';


### PR DESCRIPTION
Resolves https://github.com/pimcore/advanced-object-search/issues/191

[Name ](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-N:~:text=N-,NAME,-NAMES) and [Description](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-N:~:text=DESCRIPTION%3B%20added%20in%208.0.4%20(nonreserved)) might be reserved keywords in MySQL 8