### PR TITLE
[Task]: Update event listener in events.js

### DIFF
--- a/src/Resources/public/js/events.js
+++ b/src/Resources/public/js/events.js
@@ -17,10 +17,12 @@
  */
 pimcore.events.onAdvancedObjectSearchResult = "pimcore.advancedObjectSearch.result.initialize";
 
-//TODO: delete once support for 10.6 is dropped
+//TODO: delete once support for Pimcore 10.6 is dropped
+
 if(typeof addEventListenerCompatibilityForPlugins === "function") {
     let eventMappings = [];
     eventMappings["onAdvancedObjectSearchResult"] = pimcore.events.onAdvancedObjectSearchResult;
     addEventListenerCompatibilityForPlugins(eventMappings);
-    console.warn("Deprecation: addEventListenerCompatibilityForPlugins will be not supported in 11.");
+    console.warn("Deprecation: addEventListenerCompatibilityForPlugins will be not supported in Pimcore 11.");
+
 }

--- a/src/Resources/public/js/events.js
+++ b/src/Resources/public/js/events.js
@@ -17,11 +17,10 @@
  */
 pimcore.events.onAdvancedObjectSearchResult = "pimcore.advancedObjectSearch.result.initialize";
 
-//TODO: delete in Pimcore11 and update dependency in composer.json
+//TODO: delete once support for 10.6 is dropped
 if(typeof addEventListenerCompatibilityForPlugins === "function") {
     let eventMappings = [];
     eventMappings["onAdvancedObjectSearchResult"] = pimcore.events.onAdvancedObjectSearchResult;
     addEventListenerCompatibilityForPlugins(eventMappings);
-} else {
-    console.error("Delete addEventListenerCompatibilityForPlugins in the advanced-object-search");
+    console.warn("Deprecation: addEventListenerCompatibilityForPlugins will be not supported in 11.");
 }


### PR DESCRIPTION
Resolves https://github.com/pimcore/advanced-object-search/issues/212

`addEventListenerCompatibilityForPlugins` is only available in 10.6 and is removed from 11.
https://github.com/pimcore/pimcore/blob/445078add4b7a70c28c4d5aa4923582ea366549a/bundles/AdminBundle/Resources/public/js/pimcore/plugin/broker.js#L83-L87
and this bundle still supports both https://github.com/pimcore/advanced-object-search/blob/a989cc0bf4b138d4996283acc449b52bc5f5728e/composer.json#L13

The `else` part is removed to avoid it appearing every time on any 11 instance due `(typeof addEventListenerCompatibilityForPlugins` being always `undefined`. 
Switched to `warn` instead of `error`.