### PR TITLE
Fix processing count calculation

### DIFF
--- a/src/Command/ReindexCommand.php
+++ b/src/Command/ReindexCommand.php
@@ -69,7 +69,7 @@ class ReindexCommand extends ServiceAwareCommand
                 $list->setLimit($elementsPerLoop);
                 $list->setOffset($i * $elementsPerLoop);
 
-                $this->output->writeln('Processing ' . $class->getName() . ': ' . ($list->getOffset() + $elementsPerLoop) . '/' . $elementsTotal);
+                $this->output->writeln('Processing ' . $class->getName() . ': ' . min($list->getOffset() + $elementsPerLoop, $elementsTotal) . '/' . $elementsTotal);
 
                 $objects = $list->load();
                 foreach ($objects as $object) {


### PR DESCRIPTION
Prior to this patch the count would always be `$list->getOffset() + $elementsPerLoop` which was not the correct count. If the total number of elements was less than 100 for example, it would write:

```
Processing Article: 100/14
Processing Brand: 100/1
Processing Item: 100/248
Processing Item: 200/248
Processing Item: 300/248
Processing MainMaterials: 100/1
Processing Option: 100/31
Processing Season: 100/3
Processing SizeRange: 100/2
Processing SleeveLength: 100/1
Processing Store: 100/1
Processing Tag: 100/9
```

After this change the output would be:

```
Processing Article: 14/14
Processing Brand: 1/1
Processing Item: 100/248
Processing Item: 200/248
Processing Item: 248/248
Processing MainMaterials: 1/1
Processing Option: 31/31
Processing Season: 3/3
Processing SizeRange: 2/2
Processing SleeveLength: 1/1
Processing Store: 1/1
Processing Tag: 9/9
```