### PR TITLE
[Bug]: Make migration idempotent & replace `rename column` with `change`

### DIFF
--- a/src/Migrations/PimcoreX/Version20221130130306.php
+++ b/src/Migrations/PimcoreX/Version20221130130306.php
@@ -36,16 +36,18 @@ class Version20221130130306 extends BundleAwareMigration
     public function up(Schema $schema): void
     {
         $table = $schema->getTable(Installer::QUEUE_TABLE_NAME)->getName();
-        $query = 'ALTER TABLE %s RENAME COLUMN `o_id` TO `id`;';
-
-        $this->addSql(sprintf($query, $table));
+        if ($table->hasColumn('o_id')) {
+            $query = 'ALTER TABLE %s CHANGE COLUMN `o_id` `id` bigint DEFAULT 0 NOT NULL;';
+            $this->addSql(sprintf($query, $table));
+        }
     }
 
     public function down(Schema $schema): void
     {
         $table = $schema->getTable(Installer::QUEUE_TABLE_NAME)->getName();
-        $query = 'ALTER TABLE %s RENAME COLUMN `id` TO `o_id`;';
-
-        $this->addSql(sprintf($query, $table));
+        if ($table->hasColumn('id')) {
+            $query = 'ALTER TABLE %s CHANGE COLUMN `id` `o_id` bigint DEFAULT 0 NOT NULL;';
+            $this->addSql(sprintf($query, $table));
+        }
     }
 }


### PR DESCRIPTION
Rename column is only introduced in MariaDB 10.5, minimum requirement of MariaDB is 10.3
See also https://github.com/pimcore/web2print-tools/issues/78#issuecomment-1596683953