### PR TITLE
fix use table name when exec query

### DIFF
--- a/src/Migrations/PimcoreX/Version20221130130306.php
+++ b/src/Migrations/PimcoreX/Version20221130130306.php
@@ -35,19 +35,19 @@ class Version20221130130306 extends BundleAwareMigration
 
     public function up(Schema $schema): void
     {
-        $table = $schema->getTable(Installer::QUEUE_TABLE_NAME)->getName();
+        $table = $schema->getTable(Installer::QUEUE_TABLE_NAME);
         if ($table->hasColumn('o_id')) {
             $query = 'ALTER TABLE %s CHANGE COLUMN `o_id` `id` bigint DEFAULT 0 NOT NULL;';
-            $this->addSql(sprintf($query, $table));
+            $this->addSql(sprintf($query, $table->getName()));
         }
     }
 
     public function down(Schema $schema): void
     {
-        $table = $schema->getTable(Installer::QUEUE_TABLE_NAME)->getName();
+        $table = $schema->getTable(Installer::QUEUE_TABLE_NAME);
         if ($table->hasColumn('id')) {
             $query = 'ALTER TABLE %s CHANGE COLUMN `id` `o_id` bigint DEFAULT 0 NOT NULL;';
-            $this->addSql(sprintf($query, $table));
+            $this->addSql(sprintf($query, $table->getName()));
         }
     }
 }


### PR DESCRIPTION
both up and down functions are setting table variable with table name instead of the proper table type leading to an error when checking if table has an id column.

In Version20221130130306.php line 39:
  Call to a member function hasColumn() on string