### PR TITLE
[Bug] Wrong titles for "batch edit selected"

### DIFF
--- a/src/Resources/public/js/searchConfig/resultPanel.js
+++ b/src/Resources/public/js/searchConfig/resultPanel.js
@@ -435,7 +435,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel = Class.create(pimc
             for (var i = 0; i < selectedRows.length; i++) {
                 jobs.push(selectedRows[i].get("id"));
             }
-            this.batchOpen(columnIndex, jobs, append, remove);
+            this.batchOpen(columnIndex, jobs, append, remove, onlySelected);
 
         } else {
 
@@ -467,7 +467,7 @@ pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel = Class.create(pimc
                 success: function (columnIndex, response) {
                     var rdata = Ext.decode(response.responseText);
                     if (rdata.success && rdata.jobs) {
-                        this.batchOpen(columnIndex, rdata.jobs, append, remove);
+                        this.batchOpen(columnIndex, rdata.jobs, append, remove, onlySelected);
                     }
 
                 }.bind(this, columnIndex)


### PR DESCRIPTION
Result gird code has outdated code and missed last param onlySelected - as result user gets "Batch edit all field <Fieldname>", but choosed "batch edit selected" and as result Title is wrong:
![image (1)](https://github.com/pimcore/advanced-object-search/assets/5318027/494d5a7e-0755-44b3-8244-cc1b9a40ad56)

It's related with OnlySelected variable and it doesn't set in batchOpen function  as last param batchOpen calls. Reference in admin bundle: https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/public/js/pimcore/element/helpers/gridColumnConfig.js#L488-L509

Please review,
