### PR TITLE
Add translation for the field title

### DIFF
--- a/src/Filter/FieldDefinitionAdapter/DefaultAdapter.php
+++ b/src/Filter/FieldDefinitionAdapter/DefaultAdapter.php
@@ -28,6 +28,7 @@ use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Normalizer\NormalizerInterface;
+use Pimcore\Model\Translation;
 
 class DefaultAdapter implements FieldDefinitionAdapterInterface
 {
@@ -245,7 +246,7 @@ class DefaultAdapter implements FieldDefinitionAdapterInterface
     {
         return [new FieldSelectionInformation(
             $this->fieldDefinition->getName(),
-            $this->fieldDefinition->getTitle(),
+            Translation::getByKeyLocalized($this->fieldDefinition->getTitle(), Translation::DOMAIN_ADMIN, true, true),
             $this->fieldType,
             [
                 'operators' => [BoolQuery::MUST, BoolQuery::SHOULD, BoolQuery::MUST_NOT, FilterEntry::EXISTS, FilterEntry::NOT_EXISTS],


### PR DESCRIPTION
## Changes in this pull request  

In the AOS configuration, only field identifiers are displayed again and not the translations.

## Additional info

If you create a new filter in AOS and then want to select the field, only the normal name is displayed, without the translation 