### PR TITLE
[Bug]: exclude_classes not working correctly

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -473,8 +473,8 @@ class Service
     public function doDeleteFromIndex(Concrete $object): void
     {
         if ($this->isExcludedClass($object->getClassName())) {
-+            return;
-+       }
+            return;
+        }
         
         $params = [
             'index' => $this->getIndexName($object->getClassName()),

--- a/src/Service.php
+++ b/src/Service.php
@@ -472,6 +472,10 @@ class Service
 
     public function doDeleteFromIndex(Concrete $object): void
     {
+        if ($this->isExcludedClass($object->getClassName())) {
++            return;
++       }
+        
         $params = [
             'index' => $this->getIndexName($object->getClassName()),
             'id' => $object->getId()


### PR DESCRIPTION
Expected behavior: Pimcore should not try to request the index of exlcuded classes

Actual behavor: If you try to delete an object of an excluded class, an error occured that the index for this class does not exists

Steps to reproduce: Exclude a class and try to delete the object