### PR TITLE
Add prefix to the checksum field to prevent mapping conflicts with other fields of the same name in Pimcore classes

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -407,7 +407,7 @@ class Service
         }
 
         $checksum = crc32(json_encode($data));
-        $data['checksum'] = $checksum;
+        $data[$this->indexNamePrefix.'checksum'] = $checksum;
 
         return [
             'index' => $this->getIndexName($object->getClassName()),
@@ -439,7 +439,7 @@ class Service
 
         try {
             $indexDocument = $this->getClient()->get($params);
-            $originalChecksum = $indexDocument['_source']['checksum'] ?? -1;
+            $originalChecksum = $indexDocument['_source'][$this->indexNamePrefix.'checksum'] ?? -1;
         } catch (Exception $e) {
             $this->logger->debug($e->getMessage());
             $originalChecksum = -1;
@@ -447,7 +447,7 @@ class Service
 
         $indexUpdateParams = $this->getIndexData($object);
 
-        if ($indexUpdateParams['body']['checksum'] != $originalChecksum) {
+        if ($indexUpdateParams['body'][$this->indexNamePrefix.'checksum'] != $originalChecksum) {
             $this->getClient()->index($indexUpdateParams);
             $this->logger->info('Updates es index for data object ' . $object->getId());
             $this->getClient()->index($indexUpdateParams);


### PR DESCRIPTION
Currently if you add a field called "checksum" to a Pimcore dataobject class, this will throw the following mapping error:

`{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"object mapping for [checksum] tried to parse field [checksum] as object, but found a concrete value"}],"type":"mapper_parsing_exception","reason":"object mapping for [checksum] tried to parse field [checksum] as object, but found a concrete value"},"status":400}`
This is because the bundle itself has a checksum field being added in with the dataobject data and results in a mapping conflict with the Pimcore class field.
To fix this, I have used the bundle prefix configured by the user to name this checksum field. This prevents such conflicts.

Just like the bundle's database tables, it is always good practice to prefix this kind of things, to prevent conflicts with user developments and customization or even other bundles as well.