### PR TITLE
Fix workspace sub-query to include table name of column references

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -126,9 +126,12 @@ class AdminController extends UserAwareController
             $list->setObjectTypes(['object', 'folder', 'variant']);
 
             $conditionFilters = [];
-            $idField = 'id';
-            $keyColumn = 'key';
-            $pathColumn = 'path';
+
+            // this is necessary to properly reference the columns from the main query in the workspaces related sub-query
+            $listingTableName = $list->getDao()->getTableName();
+            $idField = $listingTableName . '.' . 'id';
+            $keyColumn = $listingTableName . '.' . 'key';
+            $pathColumn = $listingTableName . '.' . 'path';
             if (!$this->getPimcoreUser()->isAdmin()) {
                 $userIds = $this->getPimcoreUser()->getRoles();
                 $userIds[] = $this->getPimcoreUser()->getId();


### PR DESCRIPTION
Resolves #248

These changes were already implemented in the 5.x branch ([#252 ](https://github.com/pimcore/advanced-object-search/pull/252)) and are now being backported to the 6.x branch.