### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,7 @@
     "doctrine/dbal": "^3.2 || ^4.0",
     "pimcore/opensearch-client": "^2.0",
     "pimcore/elasticsearch-client": "^2.0",
-    "pimcore/pimcore": "^12.0",
-    "symfony/config": "^6.2",
-    "symfony/console": "^6.2",
-    "symfony/dependency-injection": "^6.2",
-    "symfony/event-dispatcher": "^6.2",
-    "symfony/http-foundation": "^6.3",
-    "symfony/http-kernel": "^6.2",
-    "symfony/messenger": "^6.2",
-    "symfony/routing": "^6.2"
+    "pimcore/pimcore": "^12.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.12.15",

--- a/src/Command/ProcessUpdateQueueCommand.php
+++ b/src/Command/ProcessUpdateQueueCommand.php
@@ -13,17 +13,19 @@ declare(strict_types=1);
 
 namespace AdvancedObjectSearchBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'advanced-object-search:process-update-queue',
+    description: 'processes whole update queue of es search index'
+)]
 class ProcessUpdateQueueCommand extends ServiceAwareCommand
 {
     protected function configure(): void
     {
-        $this
-            ->setName('advanced-object-search:process-update-queue')
-            ->setDescription('processes whole update queue of es search index')
-        ;
+        // Configuration moved to AsCommand attribute
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/ReindexCommand.php
+++ b/src/Command/ReindexCommand.php
@@ -15,10 +15,15 @@ namespace AdvancedObjectSearchBundle\Command;
 
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'advanced-object-search:re-index',
+    description: 'Reindex all objects of given class. Does not delete index first or resets update queue.'
+)]
 class ReindexCommand extends ServiceAwareCommand
 {
     protected ?array $indexConfiguration = null;
@@ -31,11 +36,12 @@ class ReindexCommand extends ServiceAwareCommand
 
     protected function configure(): void
     {
-        $this
-            ->setName('advanced-object-search:re-index')
-            ->setDescription('Reindex all objects of given class. Does not delete index first or resets update queue.')
-            ->addOption('classes', 'c', InputOption::VALUE_OPTIONAL, 'just update specific classes, use "," (comma) to execute more than one class')
-        ;
+        $this->addOption(
+            'classes',
+            'c',
+            InputOption::VALUE_OPTIONAL,
+            'just update specific classes, use "," (comma) to execute more than one class'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/UpdateMappingCommand.php
+++ b/src/Command/UpdateMappingCommand.php
@@ -14,19 +14,25 @@ declare(strict_types=1);
 namespace AdvancedObjectSearchBundle\Command;
 
 use Pimcore\Model\DataObject\ClassDefinition;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'advanced-object-search:update-mapping',
+    description: 'Deletes and recreates mapping of given classes. Resets update queue for given class.'
+)]
 class UpdateMappingCommand extends ServiceAwareCommand
 {
     protected function configure(): void
     {
-        $this
-            ->setName('advanced-object-search:update-mapping')
-            ->setDescription('Deletes and recreates mapping of given classes. Resets update queue for given class.')
-            ->addOption('classes', 'c', InputOption::VALUE_OPTIONAL, 'just update specific classes, use "," (comma) to execute more than one class')
-        ;
+        $this->addOption(
+            'classes',
+            'c',
+            InputOption::VALUE_OPTIONAL,
+            'just update specific classes, use "," (comma) to execute more than one class'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace AdvancedObjectSearchBundle\Controller;
 
+use Pimcore\Helper\ParameterBagHelper;
 use AdvancedObjectSearchBundle\Event\AdvancedObjectSearchEvents;
 use AdvancedObjectSearchBundle\Event\FilterListingEvent;
 use AdvancedObjectSearchBundle\Model\SavedSearch;
@@ -107,8 +108,8 @@ class AdminController extends UserAwareController
 
             $fields = $request->request->all('fields');
 
-            $limit = $request->request->getInt('limit', 20);
-            $start = $request->request->getInt('start');
+            $limit = ParameterBagHelper::getInt($request->request, 'limit', 20);
+            $start = ParameterBagHelper::getInt($request->request, 'start');
 
             $listClass = '\\Pimcore\\Model\\DataObject\\' . ucfirst($className) . '\\Listing';
 
@@ -233,7 +234,7 @@ class AdminController extends UserAwareController
         $data = $request->request->getString('data');
         $data = json_decode($data);
 
-        $id = $request->request->getInt('id');
+        $id = ParameterBagHelper::getInt($request->request, 'id');
         if ($id) {
             $savedSearch = SavedSearch::getById($id);
         } else {
@@ -258,7 +259,7 @@ class AdminController extends UserAwareController
     #[Route('/delete')]
     public function deleteAction(Request $request): JsonResponse
     {
-        $id = $request->request->getInt('id');
+        $id = ParameterBagHelper::getInt($request->request, 'id');
         $savedSearch = SavedSearch::getById($id);
 
         if ($savedSearch) {
@@ -282,8 +283,8 @@ class AdminController extends UserAwareController
 
         $query = str_replace('%', '*', $query);
 
-        $offset = $request->query->getInt('start');
-        $limit = $request->query->getInt('limit', 50);
+        $offset = ParameterBagHelper::getInt($request->query, 'start');
+        $limit = ParameterBagHelper::getInt($request->query, 'limit', 50);
 
         $db = Db::get();
         $searcherList = new SavedSearch\Listing();
@@ -353,7 +354,7 @@ class AdminController extends UserAwareController
     #[Route('/load-search')]
     public function loadSearchAction(Request $request): JsonResponse
     {
-        $id = $request->query->getInt('id');
+        $id = ParameterBagHelper::getInt($request->query, 'id');
         $savedSearch = SavedSearch::getById($id);
         if ($savedSearch) {
             $config = json_decode($savedSearch->getConfig(), true);
@@ -439,7 +440,7 @@ class AdminController extends UserAwareController
     #[Route('/toggle-short-cut')]
     public function toggleShortCutAction(Request $request): JsonResponse
     {
-        $id = $request->request->getInt('id');
+        $id = ParameterBagHelper::getInt($request->request, 'id');
         $savedSearch = SavedSearch::getById($id);
         if ($savedSearch) {
             $user = $this->getPimcoreUser();


### PR DESCRIPTION
This pull request updates how Symfony console commands are registered in the bundle by switching from method-based configuration to PHP attributes, and also simplifies dependency management in `composer.json`. The main focus is on modernizing command definitions and cleaning up redundant Symfony package requirements.

**Command registration modernization:**

* Migrated command configuration from the `configure()` method to the `AsCommand` attribute for `ProcessUpdateQueueCommand`, `ReindexCommand`, and `UpdateMappingCommand`, making command definitions more concise and leveraging Symfony's recommended approach. [[1]](diffhunk://#diff-2f61a783468823b045c598216d9d150f342709fa2ab45028eccbb869c6e2947fR16-R28) [[2]](diffhunk://#diff-c9daf587333d77061fe7985132b0f79197da5c183ecf6e24668a7525755f08f2L18-R26) [[3]](diffhunk://#diff-6f44d8b8b14325735a19cc9d0f396e84bd3139c2fcb6b5e2044a958683cc2b9bL17-R35)

**Dependency management cleanup:**

* Removed explicit Symfony component dependencies from `composer.json`, relying on them being provided transitively by `pimcore/pimcore`, which simplifies package maintenance and reduces redundancy.

**Command options handling:**

* Updated the `configure()` methods in `ReindexCommand` and `UpdateMappingCommand` to only add custom options, since name and description are now handled by attributes. [[1]](diffhunk://#diff-c9daf587333d77061fe7985132b0f79197da5c183ecf6e24668a7525755f08f2L34-R44) [[2]](diffhunk://#diff-6f44d8b8b14325735a19cc9d0f396e84bd3139c2fcb6b5e2044a958683cc2b9bL17-R35)