### PR TITLE
Fix php-cs-fixer push trigger: use branch ref instead of empty PR context

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -16,6 +16,6 @@ jobs:
         secrets:
             PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}
         with:
-            head_ref: ${{ github.event.pull_request.head.ref }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            head_ref: ${{ github.head_ref || github.ref_name }}
+            repository: ${{ github.repository }}
             config_file: .php-cs-fixer.dist.php


### PR DESCRIPTION
## Summary
`.github/workflows/php-cs-fixer.yml` triggers on `push` to this maintenance branch, but was written for `pull_request` context:

```yaml
head_ref: ${{ github.event.pull_request.head.ref }}
repository: ${{ github.event.pull_request.head.repo.full_name }}
```

On a `push` event `github.event.pull_request` does not exist, so both inputs resolve to an empty string. `reusable-php-cs-fixer.yaml` then falls back to `ref: github.sha` — a bare commit, which always checks out in **detached HEAD**. `php-cs-fixer` still computes real fixes, but `git-auto-commit-action` cannot push from detached HEAD (`fatal: You are not currently on a branch`), so every fix is silently discarded.

Same change as the proven fix pimcore/data-quality-management-bundle#328. Tracked in pimcore/service-operations#1071.

## Changes
```diff
-            head_ref: ${{ github.event.pull_request.head.ref }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            head_ref: ${{ github.head_ref || github.ref_name }}
+            repository: ${{ github.repository }}
```

## Verification
- This workflow is **push-only** on this branch, so the change has no effect on pull-request runs.
- Evidence the bug is real, not theoretical: `static-resolver-bundle@3.6` and `data-quality-management-bundle@1.7` both show `push` → PHP-CS-Fixer **failure**; `1.7` went green immediately after #328 landed.
- The workflow re-runs on the merge commit to this branch, which exercises the fixed path directly.

🤖 Generated with [Claude Code](https://claude.ai/code)
